### PR TITLE
Added macOS build action and changed build.sh

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -3,8 +3,23 @@ name: Build-App
 on: push
 
 jobs:
-  build-app:
-    name: Perform basic build of the app
+  build-app-macos:
+    name: Build for macOS platform
+    runs-on: macOS-latest
+
+    steps:
+
+      - name: Checkout repository to this container
+        uses: actions/checkout@v2
+
+      - name: Install Qt
+        run: brew install qt5 && brew link qt5 --force
+
+      - name: Build scambled-eggs
+        run: bash build.sh
+
+  build-app-linux:
+    name: Build for ubuntu linux platform
     runs-on: ubuntu-latest
 
     steps:

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 if [ ! -f ./Makefile -o ./Makefile -nt se.pro ]; then
-	qmake se.pro -o Makefile
+  mkdir -p build
+  cd build && qmake ../se.pro -o Makefile
 fi
 
 make $@

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-if [ ! -f ./Makefile -o ./Makefile -nt se.pro ]; then
+if [ ! -f ../build/Makefile -o ../build/Makefile -nt se.pro ]; then
   mkdir -p build
   cd build && qmake ../se.pro -o Makefile
 fi


### PR DESCRIPTION
So to have `qmake` put your build artifacts in a desired folder, you need to make your destination folder and call `qmake` from within the destination folder, with the relative path of the `.pro` file passed in. 